### PR TITLE
Add a bluesky Readable compliant object which works in RE

### DIFF
--- a/bluesky_hwproxy/__init__.py
+++ b/bluesky_hwproxy/__init__.py
@@ -4,3 +4,4 @@ __version__ = "0.0.1"
 
 from ._proxy import HardwareProxy
 from .comms import *
+from ._device import Device, NullStatus

--- a/bluesky_hwproxy/_device.py
+++ b/bluesky_hwproxy/_device.py
@@ -1,0 +1,56 @@
+import functools
+
+from .comms import ZMQCommSendThreads
+
+def parse_output(fn):
+    @functools.wraps(fn)
+    def inner(*args, **kwargs):
+        ret = fn(*args, **kwargs)
+        if not ret.get("success", False):
+            raise ValueError(ret.get("msg"))
+        return ret.get("return", None)
+    return inner
+
+class NullStatus:
+    @property
+    def done(self):
+        return True
+
+    @property
+    def success(self):
+        return True
+
+    def add_callback(self, callback):
+        callback(self)
+
+class Device:
+    def __init__(self, name, addr="tcp://localhost:60620"):
+        self._name = name
+        self._comm = ZMQCommSendThreads(zmq_server_address=addr)
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def parent(self):
+        return None
+
+    def trigger(self):
+        return NullStatus()
+
+    @parse_output
+    def describe(self):
+        return self._comm.send_message(method="describe", params={"device": self.name})
+
+    @parse_output
+    def read(self):
+        return self._comm.send_message(method="read", params={"device": self.name})
+
+    @parse_output
+    def describe_configuration(self):
+        return self._comm.send_message(method="describe_configuration", params={"device": self.name})
+
+    @parse_output
+    def read_configuration(self):
+        return self._comm.send_message(method="read_configuration", params={"device": self.name})

--- a/bluesky_hwproxy/comms/__init__.py
+++ b/bluesky_hwproxy/comms/__init__.py
@@ -1,5 +1,24 @@
 import functools
 
-from bluesky_queueserver.manager.comms import zmq_single_request
+from bluesky_queueserver.manager.comms import zmq_single_request, ZMQCommSendThreads
 
 zmq_single_request = functools.partial(zmq_single_request, zmq_server_address="tcp://localhost:60620")
+
+class ZMQCommSendThreads(ZMQCommSendThreads):
+    def __init__(
+        self,
+        *,
+        zmq_server_address=None,
+        timeout_recv=2000,
+        timeout_send=500,
+        raise_exceptions=True,
+        server_public_key=None,
+    ):
+        super().__init__(
+            zmq_server_address=zmq_server_address or "tcp://localhost:60620",
+            timeout_recv=timeout_recv,
+            timeout_send=timeout_send,
+            raise_exceptions=raise_exceptions,
+            server_public_key=server_public_key,
+        )
+


### PR DESCRIPTION
Maybe we should think about adding tests... I did test it ad hoc, and that is why there is the thread based comm layer here, as the zmq_single_request uses aysyncio.run, which cannot be run inside of the RE asyncio event loop, so I needed the non async variant from upstream.

So far only does Readable, will think on expanding that to at least Hinted/Checkable (and maybe other odds and ends like component names) but will do so _after_ implementing queries for protocols

Closes #7 